### PR TITLE
crawl for geom_alt prop updates

### DIFF
--- a/data/421/199/769/421199769.geojson
+++ b/data/421/199/769/421199769.geojson
@@ -642,6 +642,9 @@
     },
     "wof:country":"ER",
     "wof:created":1459010000,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9cd696d37cad171d5bd9d7f921ffd4d2",
     "wof:hierarchy":[
         {
@@ -653,7 +656,7 @@
         }
     ],
     "wof:id":421199769,
-    "wof:lastmodified":1566587078,
+    "wof:lastmodified":1582355608,
     "wof:name":"Asmara",
     "wof:parent_id":1108758301,
     "wof:placetype":"locality",

--- a/data/856/327/81/85632781.geojson
+++ b/data/856/327/81/85632781.geojson
@@ -1010,6 +1010,11 @@
     },
     "wof:country":"ER",
     "wof:country_alpha3":"ERI",
+    "wof:geom_alt":[
+        "naturalearth",
+        "naturalearth-display-terrestrial-zoom6",
+        "meso"
+    ],
     "wof:geomhash":"1a54b2d5e188cc2a046ce89930925409",
     "wof:hierarchy":[
         {
@@ -1028,7 +1033,7 @@
         "eng",
         "ara"
     ],
-    "wof:lastmodified":1566586966,
+    "wof:lastmodified":1582355602,
     "wof:name":"Eritrea",
     "wof:parent_id":102191573,
     "wof:placetype":"country",

--- a/data/856/711/01/85671101.geojson
+++ b/data/856/711/01/85671101.geojson
@@ -286,6 +286,9 @@
         "wk:page":"Gash-Barka Region"
     },
     "wof:country":"ER",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"86069dd832468458484bd126c27d2752",
     "wof:hierarchy":[
         {
@@ -305,7 +308,7 @@
         "eng",
         "ara"
     ],
-    "wof:lastmodified":1566586972,
+    "wof:lastmodified":1582355605,
     "wof:name":"Gash Barka",
     "wof:parent_id":85632781,
     "wof:placetype":"region",

--- a/data/856/711/05/85671105.geojson
+++ b/data/856/711/05/85671105.geojson
@@ -276,6 +276,9 @@
         "wk:page":"Northern Red Sea Region"
     },
     "wof:country":"ER",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8c2e79d2b69268349b946cdf8aa40079",
     "wof:hierarchy":[
         {
@@ -295,7 +298,7 @@
         "eng",
         "ara"
     ],
-    "wof:lastmodified":1566586969,
+    "wof:lastmodified":1582355604,
     "wof:name":"Debub",
     "wof:parent_id":85632781,
     "wof:placetype":"region",

--- a/data/856/711/09/85671109.geojson
+++ b/data/856/711/09/85671109.geojson
@@ -289,6 +289,9 @@
         "wk:page":"Southern Region (Eritrea)"
     },
     "wof:country":"ER",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8225f070eb1f884d4ec0155b65fdff5d",
     "wof:hierarchy":[
         {
@@ -308,7 +311,7 @@
         "eng",
         "ara"
     ],
-    "wof:lastmodified":1566586971,
+    "wof:lastmodified":1582355605,
     "wof:name":"Maekel",
     "wof:parent_id":85632781,
     "wof:placetype":"region",

--- a/data/856/711/11/85671111.geojson
+++ b/data/856/711/11/85671111.geojson
@@ -288,6 +288,9 @@
         "wk:page":"Southern Red Sea Region"
     },
     "wof:country":"ER",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1d5e0b9b09b20833ceb34c83a09fc169",
     "wof:hierarchy":[
         {
@@ -307,7 +310,7 @@
         "eng",
         "ara"
     ],
-    "wof:lastmodified":1566586971,
+    "wof:lastmodified":1582355604,
     "wof:name":"Debubawi Keyih Bahri",
     "wof:parent_id":85632781,
     "wof:placetype":"region",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.