### PR TITLE
Name updates

### DIFF
--- a/data/856/327/81/85632781.geojson
+++ b/data/856/327/81/85632781.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":10.206978,
-    "geom:area_square_m":121664757426.083832,
+    "geom:area_square_m":121664756377.291092,
     "geom:bbox":"36.433348,12.354723,43.137048,18.020414",
     "geom:latitude":15.382148,
     "geom:longitude":38.842185,
@@ -65,6 +65,9 @@
     "name:arg_x_preferred":[
         "Eritrea"
     ],
+    "name:ary_x_preferred":[
+        "\u0625\u0631\u064a\u062a\u064a\u0631\u064a\u0627"
+    ],
     "name:arz_x_preferred":[
         "\u0627\u0631\u064a\u062a\u0631\u064a\u0627"
     ],
@@ -85,6 +88,9 @@
     ],
     "name:bam_x_variant":[
         "Eritere"
+    ],
+    "name:ban_x_preferred":[
+        "\u00c9ritr\u00e9a"
     ],
     "name:bcl_x_preferred":[
         "Eritreya"
@@ -167,6 +173,12 @@
     "name:dan_x_preferred":[
         "Eritrea"
     ],
+    "name:deu_at_x_preferred":[
+        "Eritrea"
+    ],
+    "name:deu_ch_x_preferred":[
+        "Eritrea"
+    ],
     "name:deu_x_preferred":[
         "Eritrea"
     ],
@@ -187,6 +199,12 @@
     ],
     "name:ell_x_preferred":[
         "\u0395\u03c1\u03c5\u03b8\u03c1\u03b1\u03af\u03b1"
+    ],
+    "name:eng_ca_x_preferred":[
+        "Eritrea"
+    ],
+    "name:eng_gb_x_preferred":[
+        "Eritrea"
     ],
     "name:eng_x_preferred":[
         "Eritrea"
@@ -260,6 +278,9 @@
     ],
     "name:gag_x_preferred":[
         "Eritreya"
+    ],
+    "name:gcr_x_preferred":[
+        "\u00c9ritr\u00e9"
     ],
     "name:ger_x_variant":[
         "Staat Eritrea"
@@ -527,6 +548,9 @@
     "name:mon_x_preferred":[
         "\u042d\u0440\u0438\u0442\u0440\u0435\u0439"
     ],
+    "name:mri_x_preferred":[
+        "Erit\u0113ria"
+    ],
     "name:mrj_x_preferred":[
         "\u042d\u0440\u0438\u0442\u0440\u0435\u0439"
     ],
@@ -626,6 +650,9 @@
     "name:pol_x_preferred":[
         "Erytrea"
     ],
+    "name:por_br_x_preferred":[
+        "Eritreia"
+    ],
     "name:por_x_preferred":[
         "Eritreia"
     ],
@@ -716,6 +743,12 @@
     "name:srd_x_preferred":[
         "Eritrea"
     ],
+    "name:srp_ec_x_preferred":[
+        "\u0415\u0440\u0438\u0442\u0440\u0435\u0458\u0430"
+    ],
+    "name:srp_el_x_preferred":[
+        "Eritreja"
+    ],
     "name:srp_x_preferred":[
         "\u0415\u0440\u0438\u0442\u0440\u0435\u0458\u0430"
     ],
@@ -739,6 +772,9 @@
     ],
     "name:szl_x_preferred":[
         "Erytryja"
+    ],
+    "name:szy_x_preferred":[
+        "Eritrea"
     ],
     "name:tah_x_preferred":[
         "Erit\u0113re"
@@ -863,8 +899,26 @@
     "name:zha_x_preferred":[
         "Eritrea"
     ],
+    "name:zho_cn_x_preferred":[
+        "\u5384\u7acb\u7279\u91cc\u4e9a"
+    ],
+    "name:zho_hk_x_preferred":[
+        "\u5384\u7acb\u7279\u91cc\u4e9e"
+    ],
     "name:zho_min_nan_x_preferred":[
         "Eritrea"
+    ],
+    "name:zho_mo_x_preferred":[
+        "\u5384\u7acb\u7279\u91cc\u4e9e"
+    ],
+    "name:zho_my_x_preferred":[
+        "\u5384\u7acb\u7279\u91cc\u4e9a"
+    ],
+    "name:zho_sg_x_preferred":[
+        "\u5384\u7acb\u7279\u91cc\u4e9a"
+    ],
+    "name:zho_tw_x_preferred":[
+        "\u5384\u5229\u5782\u4e9e"
     ],
     "name:zho_x_preferred":[
         "\u5384\u7acb\u7279\u91cc\u4e9a"
@@ -1034,7 +1088,7 @@
         "eng",
         "ara"
     ],
-    "wof:lastmodified":1583797330,
+    "wof:lastmodified":1587428991,
     "wof:name":"Eritrea",
     "wof:parent_id":102191573,
     "wof:placetype":"country",


### PR DESCRIPTION
Fixes https://github.com/whosonfirst-data/whosonfirst-data/issues/1796 and https://github.com/whosonfirst-data/whosonfirst-data/issues/1821.

This PR includes:
- Fixes to property values that start or end with `" "`, `\n`, or `\r`, removing those characters.
- Using a modified version of the [wiki names import script](https://github.com/whosonfirst/whosonfirst-cookbook/blob/master/scripts/crawl_to_add_wiki_names.py), adds new `name` properties

There will be ~260 similar PRs, one for each per-country repo. No PIP work require, can merge as-is.