### PR TITLE
er concordances, placetype local, and more

### DIFF
--- a/data/110/875/827/3/1108758273.geojson
+++ b/data/110/875/827/3/1108758273.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.032099,
-    "geom:area_square_m":382248796.058594,
+    "geom:area_square_m":382248754.48511,
     "geom:bbox":"38.652427,15.509174,38.889452,15.709191",
     "geom:latitude":15.620626,
     "geom:longitude":38.774314,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"ER.AN.AT"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ER",
     "wof:created":1481310308,
-    "wof:geomhash":"b31095314e3d3ec84c8ff30093d6cbf5",
+    "wof:geomhash":"4ae66228df74959896c7cc9373a49d2f",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1108758273,
-    "wof:lastmodified":1627522104,
+    "wof:lastmodified":1695886577,
     "wof:name":"Adi Tekeliezan",
     "wof:parent_id":1108805927,
     "wof:placetype":"county",

--- a/data/110/875/827/5/1108758275.geojson
+++ b/data/110/875/827/5/1108758275.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.23582,
-    "geom:area_square_m":2797858835.764728,
+    "geom:area_square_m":2797858835.764802,
     "geom:bbox":"37.7446190031,16.0022108639,38.2626904199,16.7349508797",
     "geom:latitude":16.361751,
     "geom:longitude":37.973858,
@@ -67,9 +67,10 @@
     "wof:concordances":{
         "hasc:id":"ER.AN.AS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ER",
     "wof:created":1481310310,
-    "wof:geomhash":"943defc9135a9bccde32bfdc69c48fed",
+    "wof:geomhash":"06d891fbd0810911ebf15faf29199f60",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1108758275,
-    "wof:lastmodified":1566587035,
+    "wof:lastmodified":1695886660,
     "wof:name":"Asmat",
     "wof:parent_id":1108805927,
     "wof:placetype":"county",

--- a/data/110/875/827/7/1108758277.geojson
+++ b/data/110/875/827/7/1108758277.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.053069,
-    "geom:area_square_m":631757475.254975,
+    "geom:area_square_m":631757285.208873,
     "geom:bbox":"38.380188,15.548653,38.78139,15.823137",
     "geom:latitude":15.691886,
     "geom:longitude":38.563051,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"ER.AN.EL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ER",
     "wof:created":1481310311,
-    "wof:geomhash":"e7e7ac92b48065e03fb63176704f1c26",
+    "wof:geomhash":"1824db479534ad4ddef17c62bce7bdef",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1108758277,
-    "wof:lastmodified":1627522105,
+    "wof:lastmodified":1695886578,
     "wof:name":"Elabered",
     "wof:parent_id":1108805927,
     "wof:placetype":"county",

--- a/data/110/875/827/9/1108758279.geojson
+++ b/data/110/875/827/9/1108758279.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.037344,
-    "geom:area_square_m":444304500.187061,
+    "geom:area_square_m":444304354.885336,
     "geom:bbox":"38.543374,15.695826,38.863248,15.898489",
     "geom:latitude":15.808962,
     "geom:longitude":38.719048,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"ER.AN.GH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ER",
     "wof:created":1481310312,
-    "wof:geomhash":"91aaa8887e8ca27feab3c616738788b9",
+    "wof:geomhash":"bb89c7a25c7ba6046d56045960f0915c",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1108758279,
-    "wof:lastmodified":1627522106,
+    "wof:lastmodified":1695886580,
     "wof:name":"Gheleb",
     "wof:parent_id":1108805927,
     "wof:placetype":"county",

--- a/data/110/875/828/1/1108758281.geojson
+++ b/data/110/875/828/1/1108758281.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.127053,
-    "geom:area_square_m":1507645538.539268,
+    "geom:area_square_m":1507646131.758346,
     "geom:bbox":"38.052212,15.93652,38.497215,16.658258",
     "geom:latitude":16.330058,
     "geom:longitude":38.309512,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"ER.AN.HB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ER",
     "wof:created":1481310313,
-    "wof:geomhash":"da1b31f9f8d871bd2ae151ebe71c8524",
+    "wof:geomhash":"4d5c89535f413b65441c20e526b73df1",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1108758281,
-    "wof:lastmodified":1627522106,
+    "wof:lastmodified":1695886580,
     "wof:name":"Habero",
     "wof:parent_id":1108805927,
     "wof:placetype":"county",

--- a/data/110/875/828/3/1108758283.geojson
+++ b/data/110/875/828/3/1108758283.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.087467,
-    "geom:area_square_m":1040931644.153497,
+    "geom:area_square_m":1040931644.15346,
     "geom:bbox":"38.0158968472,15.5446813046,38.5226812605,15.9648043837",
     "geom:latitude":15.750884,
     "geom:longitude":38.249998,
@@ -67,9 +67,10 @@
     "wof:concordances":{
         "hasc:id":"ER.AN.HG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ER",
     "wof:created":1481310314,
-    "wof:geomhash":"9fbe4d5a15af1ac822af964dd48c8b1a",
+    "wof:geomhash":"748e6510efcd2993a3278500c2dcf426",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1108758283,
-    "wof:lastmodified":1566587038,
+    "wof:lastmodified":1695886661,
     "wof:name":"Hagaz",
     "wof:parent_id":1108805927,
     "wof:placetype":"county",

--- a/data/110/875/828/7/1108758287.geojson
+++ b/data/110/875/828/7/1108758287.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.067247,
-    "geom:area_square_m":799224290.792307,
+    "geom:area_square_m":799224416.092629,
     "geom:bbox":"38.046971,15.849844,38.366134,16.208848",
     "geom:latitude":16.020537,
     "geom:longitude":38.215596,
@@ -67,9 +67,10 @@
     "wof:concordances":{
         "hasc:id":"ER.AN.HH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ER",
     "wof:created":1481310316,
-    "wof:geomhash":"c40258cae9af8f7e26b199e161d7b06e",
+    "wof:geomhash":"d18d450df52a72ca61c0f63c3cafb48f",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1108758287,
-    "wof:lastmodified":1627522107,
+    "wof:lastmodified":1695886581,
     "wof:name":"Halhal",
     "wof:parent_id":1108805927,
     "wof:placetype":"county",

--- a/data/110/875/828/9/1108758289.geojson
+++ b/data/110/875/828/9/1108758289.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.036133,
-    "geom:area_square_m":429684485.000871,
+    "geom:area_square_m":429684502.038255,
     "geom:bbox":"38.310748,15.809878,38.571646,16.028438",
     "geom:latitude":15.904727,
     "geom:longitude":38.431756,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"ER.AN.HM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ER",
     "wof:created":1481310317,
-    "wof:geomhash":"9bd8ece0c70a7e1cd4b53dbfd435b448",
+    "wof:geomhash":"43274bf02b7b95731f9b56afd39f8d3c",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1108758289,
-    "wof:lastmodified":1627522107,
+    "wof:lastmodified":1695886581,
     "wof:name":"Hamelmalo",
     "wof:parent_id":1108805927,
     "wof:placetype":"county",

--- a/data/110/875/829/1/1108758291.geojson
+++ b/data/110/875/829/1/1108758291.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.007789,
-    "geom:area_square_m":92665907.348347,
+    "geom:area_square_m":92665915.332678,
     "geom:bbox":"38.337539,15.755265,38.490169,15.846783",
     "geom:latitude":15.803943,
     "geom:longitude":38.417555,
@@ -79,9 +79,10 @@
     "wof:concordances":{
         "hasc:id":"ER.AN.KC"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ER",
     "wof:created":1481310318,
-    "wof:geomhash":"90d9d079d682e685c15af72541ac6355",
+    "wof:geomhash":"76d5a7f3b62104cfda476a5db496210d",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -91,7 +92,7 @@
         }
     ],
     "wof:id":1108758291,
-    "wof:lastmodified":1636502502,
+    "wof:lastmodified":1695886064,
     "wof:name":"Keren",
     "wof:parent_id":1108805927,
     "wof:placetype":"county",

--- a/data/110/875/829/3/1108758293.geojson
+++ b/data/110/875/829/3/1108758293.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.307928,
-    "geom:area_square_m":3658069952.932269,
+    "geom:area_square_m":3658070041.166842,
     "geom:bbox":"37.035845,15.796982,38.061769,16.429606",
     "geom:latitude":16.109222,
     "geom:longitude":37.574299,
@@ -67,9 +67,10 @@
     "wof:concordances":{
         "hasc:id":"ER.AN.KE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ER",
     "wof:created":1481310319,
-    "wof:geomhash":"70e58ac50f4945539d1c675a030fa9f6",
+    "wof:geomhash":"d8d0aa06155815298103cb85b5e994a5",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1108758293,
-    "wof:lastmodified":1627522107,
+    "wof:lastmodified":1695886581,
     "wof:name":"Kerkebet",
     "wof:parent_id":1108805927,
     "wof:placetype":"county",

--- a/data/110/875/829/5/1108758295.geojson
+++ b/data/110/875/829/5/1108758295.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.791062,
-    "geom:area_square_m":9364171571.116982,
+    "geom:area_square_m":9364170844.972815,
     "geom:bbox":"36.859015,16.274681,37.990057,17.505165",
     "geom:latitude":16.797349,
     "geom:longitude":37.449773,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"ER.AN.SE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ER",
     "wof:created":1481310320,
-    "wof:geomhash":"5bdf5f3ea5ae3f1d7b4e1e4cdc8c8c12",
+    "wof:geomhash":"a4238e51f9de5603ad78ba90fcc11116",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1108758295,
-    "wof:lastmodified":1627522108,
+    "wof:lastmodified":1695886582,
     "wof:name":"Sela'",
     "wof:parent_id":1108805927,
     "wof:placetype":"county",

--- a/data/110/875/829/7/1108758297.geojson
+++ b/data/110/875/829/7/1108758297.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.022716,
-    "geom:area_square_m":270831749.022156,
+    "geom:area_square_m":270831699.679994,
     "geom:bbox":"38.735513,15.284015,38.911404,15.48719",
     "geom:latitude":15.374573,
     "geom:longitude":38.825182,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"ER.MA.BE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ER",
     "wof:created":1481310322,
-    "wof:geomhash":"2f5d76f589f61325d1b45400388aedbd",
+    "wof:geomhash":"9b808ddf9e7fb79b91dd2937d6799456",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1108758297,
-    "wof:lastmodified":1627522105,
+    "wof:lastmodified":1695886578,
     "wof:name":"Berik",
     "wof:parent_id":1108805925,
     "wof:placetype":"county",

--- a/data/110/875/829/9/1108758299.geojson
+++ b/data/110/875/829/9/1108758299.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.002213,
-    "geom:area_square_m":26391940.960132,
+    "geom:area_square_m":26391887.284847,
     "geom:bbox":"38.925957,15.286349,38.980966,15.355955",
     "geom:latitude":15.321504,
     "geom:longitude":38.9522,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"ER.MA.SE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ER",
     "wof:created":1481310323,
-    "wof:geomhash":"d89945f879804a1797825035fd55642a",
+    "wof:geomhash":"be149b640b050aaa8ce212390822ef7b",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1108758299,
-    "wof:lastmodified":1627522105,
+    "wof:lastmodified":1695886578,
     "wof:name":"Debubawi Mibrak",
     "wof:parent_id":1108805925,
     "wof:placetype":"county",

--- a/data/110/875/830/1/1108758301.geojson
+++ b/data/110/875/830/1/1108758301.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.002081,
-    "geom:area_square_m":24815700.962448,
+    "geom:area_square_m":24815774.711686,
     "geom:bbox":"38.886052,15.2792,38.935015,15.342001",
     "geom:latitude":15.306976,
     "geom:longitude":38.911365,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"ER.MA.SW"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ER",
     "wof:created":1481310324,
-    "wof:geomhash":"4ef20a46f937d603ef066cd927dfb521",
+    "wof:geomhash":"1171400fd3ae4b482ef7d594493fe9b8",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1108758301,
-    "wof:lastmodified":1627522105,
+    "wof:lastmodified":1695886578,
     "wof:name":"Debubawi Mierab",
     "wof:parent_id":1108805925,
     "wof:placetype":"county",

--- a/data/110/875/830/5/1108758305.geojson
+++ b/data/110/875/830/5/1108758305.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.032739,
-    "geom:area_square_m":390560632.952841,
+    "geom:area_square_m":390560637.372971,
     "geom:bbox":"38.695835,15.168501,39.046215,15.359898",
     "geom:latitude":15.256032,
     "geom:longitude":38.896379,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"ER.MA.GN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ER",
     "wof:created":1481310325,
-    "wof:geomhash":"45f7df27ceb3fec1575a7341d36a16cf",
+    "wof:geomhash":"1ae0ef7e4e8547e885385c214884e16c",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1108758305,
-    "wof:lastmodified":1627522106,
+    "wof:lastmodified":1695886580,
     "wof:name":"Galanefhi",
     "wof:parent_id":1108805925,
     "wof:placetype":"county",

--- a/data/110/875/830/7/1108758307.geojson
+++ b/data/110/875/830/7/1108758307.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000528,
-    "geom:area_square_m":6292268.381973,
+    "geom:area_square_m":6292384.011891,
     "geom:bbox":"38.93493,15.338313,38.973223,15.368047",
     "geom:latitude":15.351775,
     "geom:longitude":38.954678,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"ER.MA.NE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ER",
     "wof:created":1481310326,
-    "wof:geomhash":"2776f48ac64a0790a9d3e782b03af3db",
+    "wof:geomhash":"7f68cc834d43d6938865f26dfa8bae4f",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1108758307,
-    "wof:lastmodified":1627522108,
+    "wof:lastmodified":1695886583,
     "wof:name":"Semienawi Mibrak",
     "wof:parent_id":1108805925,
     "wof:placetype":"county",

--- a/data/110/875/830/9/1108758309.geojson
+++ b/data/110/875/830/9/1108758309.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.00334,
-    "geom:area_square_m":39824429.681487,
+    "geom:area_square_m":39824351.662523,
     "geom:bbox":"38.901961,15.338294,38.96406,15.417084",
     "geom:latitude":15.378317,
     "geom:longitude":38.933141,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"ER.MA.NW"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ER",
     "wof:created":1481310332,
-    "wof:geomhash":"599fdd1a6a0cc46cb31345a3404919b4",
+    "wof:geomhash":"b2ad817d8bf18971363090a2fbcf7727",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1108758309,
-    "wof:lastmodified":1627522108,
+    "wof:lastmodified":1695886583,
     "wof:name":"Semienawi Mierab",
     "wof:parent_id":1108805925,
     "wof:placetype":"county",

--- a/data/110/875/831/1/1108758311.geojson
+++ b/data/110/875/831/1/1108758311.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.024008,
-    "geom:area_square_m":286113915.820423,
+    "geom:area_square_m":286114208.8061,
     "geom:bbox":"38.742052,15.345051,39.023648,15.570337",
     "geom:latitude":15.467377,
     "geom:longitude":38.893549,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"ER.MA.SJ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ER",
     "wof:created":1481310333,
-    "wof:geomhash":"ec31e922fd87fefa7b1158344d5be97f",
+    "wof:geomhash":"a7c60956d72558cf87047e46d99a6a04",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1108758311,
-    "wof:lastmodified":1627522108,
+    "wof:lastmodified":1695886583,
     "wof:name":"Serejeka",
     "wof:parent_id":1108805925,
     "wof:placetype":"county",

--- a/data/110/875/831/3/1108758313.geojson
+++ b/data/110/875/831/3/1108758313.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.030052,
-    "geom:area_square_m":357981010.845735,
+    "geom:area_square_m":357981284.135675,
     "geom:bbox":"37.80797,15.471103,38.059646,15.64603",
     "geom:latitude":15.555997,
     "geom:longitude":37.923126,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"ER.GB.AC"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ER",
     "wof:created":1481310334,
-    "wof:geomhash":"a8395f3c0cc3ea7435b77b7ee5900dbd",
+    "wof:geomhash":"05ed730a5f65147b6f83c1ba6b7ccfa7",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1108758313,
-    "wof:lastmodified":1627522104,
+    "wof:lastmodified":1695886577,
     "wof:name":"Akurdet",
     "wof:parent_id":85671101,
     "wof:placetype":"county",

--- a/data/110/875/831/5/1108758315.geojson
+++ b/data/110/875/831/5/1108758315.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.027972,
-    "geom:area_square_m":333942342.239923,
+    "geom:area_square_m":333942500.148139,
     "geom:bbox":"37.521231,15.002035,37.791979,15.175518",
     "geom:latitude":15.098581,
     "geom:longitude":37.65969,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"ER.GB.BC"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ER",
     "wof:created":1481310336,
-    "wof:geomhash":"c5dd8b82dce7070ef9effc6f97e6e478",
+    "wof:geomhash":"b3516c415580b0c776c0c5f8c3ff0851",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1108758315,
-    "wof:lastmodified":1627522105,
+    "wof:lastmodified":1695886578,
     "wof:name":"Barentu",
     "wof:parent_id":85671101,
     "wof:placetype":"county",

--- a/data/110/875/831/7/1108758317.geojson
+++ b/data/110/875/831/7/1108758317.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.314006,
-    "geom:area_square_m":3738009160.753826,
+    "geom:area_square_m":3738008282.198638,
     "geom:bbox":"37.116328,15.427036,37.996238,16.013406",
     "geom:latitude":15.693219,
     "geom:longitude":37.528715,
@@ -76,9 +76,10 @@
     "wof:concordances":{
         "hasc:id":"ER.GB.DG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ER",
     "wof:created":1481310337,
-    "wof:geomhash":"832923ca743fc4ce31c611fac917dffb",
+    "wof:geomhash":"9844d5d456331eeab3aa80f61b311252",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -88,7 +89,7 @@
         }
     ],
     "wof:id":1108758317,
-    "wof:lastmodified":1627522105,
+    "wof:lastmodified":1695886578,
     "wof:name":"Dige",
     "wof:parent_id":85671101,
     "wof:placetype":"county",

--- a/data/110/875/831/9/1108758319.geojson
+++ b/data/110/875/831/9/1108758319.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.384164,
-    "geom:area_square_m":4570660842.233804,
+    "geom:area_square_m":4570661571.471078,
     "geom:bbox":"36.572257,15.321785,37.356038,16.321411",
     "geom:latitude":15.803522,
     "geom:longitude":36.962657,
@@ -70,9 +70,10 @@
     "wof:concordances":{
         "hasc:id":"ER.GB.FO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ER",
     "wof:created":1481310338,
-    "wof:geomhash":"2e8e1ebf83026fb2afd2fe9dc7d396a9",
+    "wof:geomhash":"64560c7763827e9597ee3266b3577a2c",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -82,7 +83,7 @@
         }
     ],
     "wof:id":1108758319,
-    "wof:lastmodified":1627522106,
+    "wof:lastmodified":1695886580,
     "wof:name":"Forto",
     "wof:parent_id":85671101,
     "wof:placetype":"county",

--- a/data/110/875/832/3/1108758323.geojson
+++ b/data/110/875/832/3/1108758323.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.217401,
-    "geom:area_square_m":2594882354.662866,
+    "geom:area_square_m":2594882971.048202,
     "geom:bbox":"37.167388,14.776681,37.687299,15.513758",
     "geom:latitude":15.139854,
     "geom:longitude":37.393845,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"ER.GB.GG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ER",
     "wof:created":1481310339,
-    "wof:geomhash":"d27eed4431c872c1749444f3ceb9c518",
+    "wof:geomhash":"5d35b8167cf843e53870a362a5513d3e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1108758323,
-    "wof:lastmodified":1627522106,
+    "wof:lastmodified":1695886580,
     "wof:name":"Gogne",
     "wof:parent_id":85671101,
     "wof:placetype":"county",

--- a/data/110/875/832/5/1108758325.geojson
+++ b/data/110/875/832/5/1108758325.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.187095,
-    "geom:area_square_m":2232234798.141771,
+    "geom:area_square_m":2232234529.182623,
     "geom:bbox":"36.705708,14.960616,37.214799,15.468035",
     "geom:latitude":15.228128,
     "geom:longitude":36.985376,
@@ -73,9 +73,10 @@
     "wof:concordances":{
         "hasc:id":"ER.GB.HA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ER",
     "wof:created":1481310341,
-    "wof:geomhash":"6573ba6fc685fa0b9a6bba5f9137efd8",
+    "wof:geomhash":"c358744734fbd0638d5f095f973f238b",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -85,7 +86,7 @@
         }
     ],
     "wof:id":1108758325,
-    "wof:lastmodified":1627522107,
+    "wof:lastmodified":1695886581,
     "wof:name":"Haykota",
     "wof:parent_id":85671101,
     "wof:placetype":"county",

--- a/data/110/875/832/7/1108758327.geojson
+++ b/data/110/875/832/7/1108758327.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.342815,
-    "geom:area_square_m":4101473032.052612,
+    "geom:area_square_m":4101472570.638507,
     "geom:bbox":"37.060161,14.180792,37.781877,15.062882",
     "geom:latitude":14.632721,
     "geom:longitude":37.404775,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"ER.GB.UG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ER",
     "wof:created":1481310342,
-    "wof:geomhash":"a152f8e7096a7a1fd17d46fd3ed18392",
+    "wof:geomhash":"f8f78be08b95286c5862a4454c66bbfc",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1108758327,
-    "wof:lastmodified":1627522107,
+    "wof:lastmodified":1695886581,
     "wof:name":"Lae'lay Gash",
     "wof:parent_id":85671101,
     "wof:placetype":"county",

--- a/data/110/875/832/9/1108758329.geojson
+++ b/data/110/875/832/9/1108758329.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.052516,
-    "geom:area_square_m":625970097.522869,
+    "geom:area_square_m":625970006.909876,
     "geom:bbox":"38.520457,15.211367,38.769814,15.591964",
     "geom:latitude":15.429594,
     "geom:longitude":38.661849,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"ER.GB.LA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ER",
     "wof:created":1481310343,
-    "wof:geomhash":"69b63f6353d2dbb592a0b6b3cfd24055",
+    "wof:geomhash":"e6d990436609ce74521afff8c882e027",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1108758329,
-    "wof:lastmodified":1627522107,
+    "wof:lastmodified":1695886582,
     "wof:name":"Logo Anseba",
     "wof:parent_id":85671101,
     "wof:placetype":"county",

--- a/data/110/875/833/1/1108758331.geojson
+++ b/data/110/875/833/1/1108758331.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.242039,
-    "geom:area_square_m":2884747300.536111,
+    "geom:area_square_m":2884747776.959724,
     "geom:bbox":"37.93148,15.155366,38.622106,15.800875",
     "geom:latitude":15.446507,
     "geom:longitude":38.241708,
@@ -54,9 +54,10 @@
     "wof:concordances":{
         "hasc:id":"ER.BA.MA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ER",
     "wof:created":1481310344,
-    "wof:geomhash":"6bb8c93a05cc4a1d16791f574258e49e",
+    "wof:geomhash":"f1cab28d95a34fe04d0af7971bfba2f9",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -66,7 +67,7 @@
         }
     ],
     "wof:id":1108758331,
-    "wof:lastmodified":1627522107,
+    "wof:lastmodified":1695886582,
     "wof:name":"Mensura",
     "wof:parent_id":85671101,
     "wof:placetype":"county",

--- a/data/110/875/833/3/1108758333.geojson
+++ b/data/110/875/833/3/1108758333.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.153725,
-    "geom:area_square_m":1833353335.137159,
+    "geom:area_square_m":1833353130.86697,
     "geom:bbox":"37.437088,15.147797,38.035608,15.491575",
     "geom:latitude":15.312422,
     "geom:longitude":37.739199,
@@ -67,9 +67,10 @@
     "wof:concordances":{
         "hasc:id":"ER.GB.MG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ER",
     "wof:created":1481310345,
-    "wof:geomhash":"73d2b485a2fe4b9651d1ff4e24b20f84",
+    "wof:geomhash":"bfd3ea584b2daa440f4531a181e97d08",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1108758333,
-    "wof:lastmodified":1627522108,
+    "wof:lastmodified":1695886583,
     "wof:name":"Mogolo",
     "wof:parent_id":85671101,
     "wof:placetype":"county",

--- a/data/110/875/833/5/1108758335.geojson
+++ b/data/110/875/833/5/1108758335.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.196914,
-    "geom:area_square_m":2351901217.675105,
+    "geom:area_square_m":2351901107.985035,
     "geom:bbox":"37.968249,14.67036,38.706437,15.317573",
     "geom:latitude":15.000105,
     "geom:longitude":38.279459,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"ER.GB.MQ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ER",
     "wof:created":1481310346,
-    "wof:geomhash":"cc79e7e95ec81ca32808c2d6a4d3d507",
+    "wof:geomhash":"d8dacbb1628171d965c3bcd05f9be516",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1108758335,
-    "wof:lastmodified":1627522108,
+    "wof:lastmodified":1695886583,
     "wof:name":"Molqi",
     "wof:parent_id":85671101,
     "wof:placetype":"county",

--- a/data/110/875/833/7/1108758337.geojson
+++ b/data/110/875/833/7/1108758337.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.425156,
-    "geom:area_square_m":5086049664.485719,
+    "geom:area_square_m":5086049936.474463,
     "geom:bbox":"36.460058,14.252015,37.1363,15.045467",
     "geom:latitude":14.655829,
     "geom:longitude":36.792015,
@@ -57,9 +57,10 @@
     "wof:concordances":{
         "hasc:id":"ER.GS.OM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ER",
     "wof:created":1481310347,
-    "wof:geomhash":"a4725e2602d50532a47887952876352c",
+    "wof:geomhash":"6b3c01a0734d32549d59111ff61fd8d9",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -69,7 +70,7 @@
         }
     ],
     "wof:id":1108758337,
-    "wof:lastmodified":1627522108,
+    "wof:lastmodified":1695886583,
     "wof:name":"Omhajer",
     "wof:parent_id":85671101,
     "wof:placetype":"county",

--- a/data/110/875/834/1/1108758341.geojson
+++ b/data/110/875/834/1/1108758341.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.139941,
-    "geom:area_square_m":1671762012.703785,
+    "geom:area_square_m":1671762315.217,
     "geom:bbox":"37.668827,14.652653,38.139521,15.188762",
     "geom:latitude":14.958761,
     "geom:longitude":37.892636,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"ER.GB.SH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ER",
     "wof:created":1481310348,
-    "wof:geomhash":"6a5af5f879c0eee5054a10bab829150f",
+    "wof:geomhash":"4e47a375b762a0cbf7d57c0afc1bb60f",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1108758341,
-    "wof:lastmodified":1627522109,
+    "wof:lastmodified":1695886584,
     "wof:name":"Shambuqo",
     "wof:parent_id":85671101,
     "wof:placetype":"county",

--- a/data/110/875/834/3/1108758343.geojson
+++ b/data/110/875/834/3/1108758343.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.093089,
-    "geom:area_square_m":1111101161.469318,
+    "geom:area_square_m":1111100764.876458,
     "geom:bbox":"36.433348,14.989201,36.930998,15.366918",
     "geom:latitude":15.141574,
     "geom:longitude":36.640064,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"ER.GB.TE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ER",
     "wof:created":1481310350,
-    "wof:geomhash":"644744fce20a3513de238ba107855d0f",
+    "wof:geomhash":"d7bbf840bcf1b70d89cb13e2560f3877",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1108758343,
-    "wof:lastmodified":1627522109,
+    "wof:lastmodified":1695886584,
     "wof:name":"Tesseney",
     "wof:parent_id":85671101,
     "wof:placetype":"county",

--- a/data/110/875/834/5/1108758345.geojson
+++ b/data/110/875/834/5/1108758345.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.248539,
-    "geom:area_square_m":2935432339.393561,
+    "geom:area_square_m":2935432735.244671,
     "geom:bbox":"37.850879,16.82115,38.328208,17.584718",
     "geom:latitude":17.222135,
     "geom:longitude":38.082349,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"ER.SK.AD"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ER",
     "wof:created":1481310351,
-    "wof:geomhash":"d629a7e90d2fe63094ddebc54d11a7de",
+    "wof:geomhash":"6c5a083e26198935580d269ba4956ba3",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1108758345,
-    "wof:lastmodified":1627522104,
+    "wof:lastmodified":1695886577,
     "wof:name":"Adobha",
     "wof:parent_id":85671105,
     "wof:placetype":"county",

--- a/data/110/875/834/7/1108758347.geojson
+++ b/data/110/875/834/7/1108758347.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.609094,
-    "geom:area_square_m":7225884768.270886,
+    "geom:area_square_m":7225884831.946918,
     "geom:bbox":"38.432188,15.87318,39.537569,16.927388",
     "geom:latitude":16.377843,
     "geom:longitude":38.848512,
@@ -98,9 +98,10 @@
         "hasc:id":"ER.SK.AF",
         "wd:id":"Q2081367"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ER",
     "wof:created":1481310352,
-    "wof:geomhash":"d2b2307045d4bc197b184b0345b8088b",
+    "wof:geomhash":"cdf2e249425462bdda8c935708797f88",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -110,7 +111,7 @@
         }
     ],
     "wof:id":1108758347,
-    "wof:lastmodified":1690877007,
+    "wof:lastmodified":1695886661,
     "wof:name":"Afa'bet",
     "wof:parent_id":85671105,
     "wof:placetype":"county",

--- a/data/110/875/834/9/1108758349.geojson
+++ b/data/110/875/834/9/1108758349.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.094402,
-    "geom:area_square_m":1123178915.988053,
+    "geom:area_square_m":1123178993.826911,
     "geom:bbox":"39.532055,15.371222,40.859585,16.549583",
     "geom:latitude":15.801442,
     "geom:longitude":40.148201,
@@ -79,9 +79,10 @@
     "wof:concordances":{
         "hasc:id":"ER.SK.DA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ER",
     "wof:created":1481310353,
-    "wof:geomhash":"3c8b9f90acbf1941ee6d3cd58ee9a0f7",
+    "wof:geomhash":"b21b979fdb6350cf33b74c37a9955255",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -91,7 +92,7 @@
         }
     ],
     "wof:id":1108758349,
-    "wof:lastmodified":1627522105,
+    "wof:lastmodified":1695886579,
     "wof:name":"Dahlak",
     "wof:parent_id":85671105,
     "wof:placetype":"county",

--- a/data/110/875/835/1/1108758351.geojson
+++ b/data/110/875/835/1/1108758351.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.22732,
-    "geom:area_square_m":2712685416.133004,
+    "geom:area_square_m":2712685348.186629,
     "geom:bbox":"39.191993,14.834026,39.831072,15.537917",
     "geom:latitude":15.186206,
     "geom:longitude":39.528788,
@@ -79,9 +79,10 @@
     "wof:concordances":{
         "hasc:id":"ER.SK.FO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ER",
     "wof:created":1481310354,
-    "wof:geomhash":"f8afe97c4a0112866d9ce32bd3aa89d2",
+    "wof:geomhash":"2f43143f89b561e14b725c0be9aaab41",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -91,7 +92,7 @@
         }
     ],
     "wof:id":1108758351,
-    "wof:lastmodified":1627522106,
+    "wof:lastmodified":1695886580,
     "wof:name":"Foro",
     "wof:parent_id":85671105,
     "wof:placetype":"county",

--- a/data/110/875/835/3/1108758353.geojson
+++ b/data/110/875/835/3/1108758353.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.57642,
-    "geom:area_square_m":6890419534.641509,
+    "geom:area_square_m":6890418840.203008,
     "geom:bbox":"39.605054,14.299216,40.572149,15.582084",
     "geom:latitude":14.818505,
     "geom:longitude":40.088122,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"ER.SK.GL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ER",
     "wof:created":1481310356,
-    "wof:geomhash":"7deb6070b5458066237ed32989c12c36",
+    "wof:geomhash":"efbdf176bd380b2345d86b959edab942",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1108758353,
-    "wof:lastmodified":1627522106,
+    "wof:lastmodified":1695886580,
     "wof:name":"Ghelae'lo",
     "wof:parent_id":85671105,
     "wof:placetype":"county",

--- a/data/110/875/835/5/1108758355.geojson
+++ b/data/110/875/835/5/1108758355.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.168445,
-    "geom:area_square_m":2007158305.932185,
+    "geom:area_square_m":2007158387.971943,
     "geom:bbox":"38.867138,15.215135,39.43713,15.740871",
     "geom:latitude":15.493661,
     "geom:longitude":39.15172,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"ER.SK.GD"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ER",
     "wof:created":1481310357,
-    "wof:geomhash":"dba57696cb32ca7c50470e118f9f532e",
+    "wof:geomhash":"4f59054f1b2fe4063885cb52003bfbb1",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1108758355,
-    "wof:lastmodified":1627522106,
+    "wof:lastmodified":1695886581,
     "wof:name":"Ghinda'e",
     "wof:parent_id":85671105,
     "wof:placetype":"county",

--- a/data/110/875/835/9/1108758359.geojson
+++ b/data/110/875/835/9/1108758359.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.567225,
-    "geom:area_square_m":6695035545.261169,
+    "geom:area_square_m":6695035545.261762,
     "geom:bbox":"38.2498042099,16.7655260999,39.059581757,18.020413782",
     "geom:latitude":17.339317,
     "geom:longitude":38.626942,
@@ -94,9 +94,10 @@
     "wof:concordances":{
         "hasc:id":"ER.SK.KA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ER",
     "wof:created":1481310358,
-    "wof:geomhash":"b47727548391b5e91515a61df42fdfb6",
+    "wof:geomhash":"f30626436e27d5135aef0941533e0c0c",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -106,7 +107,7 @@
         }
     ],
     "wof:id":1108758359,
-    "wof:lastmodified":1566587038,
+    "wof:lastmodified":1695886661,
     "wof:name":"Karura",
     "wof:parent_id":85671105,
     "wof:placetype":"county",

--- a/data/110/875/836/1/1108758361.geojson
+++ b/data/110/875/836/1/1108758361.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.027443,
-    "geom:area_square_m":326773657.520587,
+    "geom:area_square_m":326773780.382287,
     "geom:bbox":"39.29083,15.513518,39.482082,15.772908",
     "geom:latitude":15.641809,
     "geom:longitude":39.3918,
@@ -196,9 +196,10 @@
     "wof:concordances":{
         "hasc:id":"ER.SK.MA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ER",
     "wof:created":1481310360,
-    "wof:geomhash":"b2f57d1f0d6eef85ed5d5aae84e40e59",
+    "wof:geomhash":"d197c4370293dde2f0bd1c963876de27",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -208,7 +209,7 @@
         }
     ],
     "wof:id":1108758361,
-    "wof:lastmodified":1636502502,
+    "wof:lastmodified":1695886064,
     "wof:name":"Massawa",
     "wof:parent_id":85671105,
     "wof:placetype":"county",

--- a/data/110/875/836/3/1108758363.geojson
+++ b/data/110/875/836/3/1108758363.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.262191,
-    "geom:area_square_m":3104428936.203398,
+    "geom:area_square_m":3104428936.203383,
     "geom:bbox":"37.9676877034,16.3619711215,38.5892087961,17.0973259272",
     "geom:latitude":16.752487,
     "geom:longitude":38.322913,
@@ -79,9 +79,10 @@
     "wof:concordances":{
         "hasc:id":"ER.SK.NA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ER",
     "wof:created":1481310361,
-    "wof:geomhash":"7bea33f8b106940e99c7746dccc1f168",
+    "wof:geomhash":"6b4446be859af2d63413f0eda27f1eab",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -91,7 +92,7 @@
         }
     ],
     "wof:id":1108758363,
-    "wof:lastmodified":1566587049,
+    "wof:lastmodified":1695886661,
     "wof:name":"Nakfa",
     "wof:parent_id":85671105,
     "wof:placetype":"county",

--- a/data/110/875/836/5/1108758365.geojson
+++ b/data/110/875/836/5/1108758365.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.163149,
-    "geom:area_square_m":1940818997.726908,
+    "geom:area_square_m":1940819183.032683,
     "geom:bbox":"38.748451,15.601663,39.443722,16.034057",
     "geom:latitude":15.833637,
     "geom:longitude":39.093847,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"ER.SK.SH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ER",
     "wof:created":1481310362,
-    "wof:geomhash":"e9fc44e423f93b72d71a17162efaaf2e",
+    "wof:geomhash":"d98250fbdaccd82b714f57b121054ff4",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1108758365,
-    "wof:lastmodified":1627522109,
+    "wof:lastmodified":1695886584,
     "wof:name":"Shie'b",
     "wof:parent_id":85671105,
     "wof:placetype":"county",

--- a/data/110/875/836/7/1108758367.geojson
+++ b/data/110/875/836/7/1108758367.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.580227,
-    "geom:area_square_m":6949844531.645112,
+    "geom:area_square_m":6949844432.430688,
     "geom:bbox":"40.477716,13.799927,41.534304,15.022083",
     "geom:latitude":14.377947,
     "geom:longitude":40.955461,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"ER.DK.AR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ER",
     "wof:created":1481310364,
-    "wof:geomhash":"b76dbf2fe3e5f856617be29f42362607",
+    "wof:geomhash":"c928865d7e94f79533c16ef303c627f4",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1108758367,
-    "wof:lastmodified":1627522104,
+    "wof:lastmodified":1695886577,
     "wof:name":"Ara'eta",
     "wof:parent_id":85671111,
     "wof:placetype":"county",

--- a/data/110/875/836/9/1108758369.geojson
+++ b/data/110/875/836/9/1108758369.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.040284,
-    "geom:area_square_m":485438523.960533,
+    "geom:area_square_m":485438719.802656,
     "geom:bbox":"42.581096,12.820416,43.068753,13.096647",
     "geom:latitude":12.956074,
     "geom:longitude":42.716516,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"ER.DK.AC"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ER",
     "wof:created":1481310365,
-    "wof:geomhash":"c472d6e675c111da6e17bd0da04bc670",
+    "wof:geomhash":"0738a6b2d9341a185daddfef51a39378",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1108758369,
-    "wof:lastmodified":1627522105,
+    "wof:lastmodified":1695886579,
     "wof:name":"Asseb",
     "wof:parent_id":85671111,
     "wof:placetype":"county",

--- a/data/110/875/837/1/1108758371.geojson
+++ b/data/110/875/837/1/1108758371.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.810468,
-    "geom:area_square_m":9762257960.527496,
+    "geom:area_square_m":9762257387.050976,
     "geom:bbox":"41.669447,12.387868,43.137048,13.800327",
     "geom:latitude":13.059381,
     "geom:longitude":42.2945,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"ER.DK.SS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ER",
     "wof:created":1481310366,
-    "wof:geomhash":"f96ffb6230c08c00760f98d903a32d4d",
+    "wof:geomhash":"150e40c3298f595bfada06c0c17cce60",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1108758371,
-    "wof:lastmodified":1627522105,
+    "wof:lastmodified":1695886579,
     "wof:name":"Debub Debubawi Keih Bahri",
     "wof:parent_id":85671111,
     "wof:placetype":"county",

--- a/data/110/875/837/3/1108758373.geojson
+++ b/data/110/875/837/3/1108758373.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.351123,
-    "geom:area_square_m":4216932364.547247,
+    "geom:area_square_m":4216932004.340996,
     "geom:bbox":"41.130928,13.321913,42.037083,14.164686",
     "geom:latitude":13.768986,
     "geom:longitude":41.540861,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"ER.DK.CS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ER",
     "wof:created":1481310367,
-    "wof:geomhash":"5a860dc11ddd3414398405c4bb1d19ab",
+    "wof:geomhash":"529cc67fab005daa3cc36dbba6dcab24",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1108758373,
-    "wof:lastmodified":1627522107,
+    "wof:lastmodified":1695886582,
     "wof:name":"Maekel Debubawi Keih Bahri",
     "wof:parent_id":85671111,
     "wof:placetype":"county",

--- a/data/110/875/837/7/1108758377.geojson
+++ b/data/110/875/837/7/1108758377.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.060305,
-    "geom:area_square_m":720617119.071042,
+    "geom:area_square_m":720617169.398265,
     "geom:bbox":"39.26069,14.73572,39.529389,15.098138",
     "geom:latitude":14.899192,
     "geom:longitude":39.391756,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"ER.DU.AK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ER",
     "wof:created":1481310368,
-    "wof:geomhash":"562524fc1456a217d8c5b09a7396291a",
+    "wof:geomhash":"86fbf182e77f5c8c5cfbc44dc0c50a34",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1108758377,
-    "wof:lastmodified":1627522104,
+    "wof:lastmodified":1695886578,
     "wof:name":"Adi Keih",
     "wof:parent_id":85671109,
     "wof:placetype":"county",

--- a/data/110/875/837/9/1108758379.geojson
+++ b/data/110/875/837/9/1108758379.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.05957,
-    "geom:area_square_m":712815118.032207,
+    "geom:area_square_m":712815091.57345,
     "geom:bbox":"38.67815,14.46003,39.02699,14.763952",
     "geom:latitude":14.596701,
     "geom:longitude":38.848522,
@@ -106,9 +106,10 @@
     "wof:concordances":{
         "hasc:id":"ER.DU.AQ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ER",
     "wof:created":1481310369,
-    "wof:geomhash":"e081f31d4ba4ffd992189a4f455d9788",
+    "wof:geomhash":"bc8b9f800c6cd3b3d0cb1bf3d2571860",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -118,7 +119,7 @@
         }
     ],
     "wof:id":1108758379,
-    "wof:lastmodified":1627522104,
+    "wof:lastmodified":1695886578,
     "wof:name":"Adi Quala",
     "wof:parent_id":85671109,
     "wof:placetype":"county",

--- a/data/110/875/838/1/1108758381.geojson
+++ b/data/110/875/838/1/1108758381.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.107367,
-    "geom:area_square_m":1283146938.666177,
+    "geom:area_square_m":1283146839.042553,
     "geom:bbox":"38.199216,14.666035,38.685381,15.091094",
     "geom:latitude":14.871567,
     "geom:longitude":38.5024,
@@ -67,9 +67,10 @@
     "wof:concordances":{
         "hasc:id":"ER.DU.AR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ER",
     "wof:created":1481310371,
-    "wof:geomhash":"584727cd90cfac4f0b90b951485fd93c",
+    "wof:geomhash":"ca0644d6f9f9d14e9ce64148363e50c5",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1108758381,
-    "wof:lastmodified":1627522104,
+    "wof:lastmodified":1695886578,
     "wof:name":"Areza",
     "wof:parent_id":85671109,
     "wof:placetype":"county",

--- a/data/110/875/838/3/1108758383.geojson
+++ b/data/110/875/838/3/1108758383.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.080236,
-    "geom:area_square_m":957840391.242034,
+    "geom:area_square_m":957840486.717623,
     "geom:bbox":"38.38361,14.976044,38.921094,15.234907",
     "geom:latitude":15.107962,
     "geom:longitude":38.711238,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"ER.DU.DB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ER",
     "wof:created":1481310373,
-    "wof:geomhash":"0087eef9c67bbe1ef3c988fd5e5a2d21",
+    "wof:geomhash":"42c6d77f9795ebfe2b058a46d7e7d5d8",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1108758383,
-    "wof:lastmodified":1627522105,
+    "wof:lastmodified":1695886579,
     "wof:name":"Dbarwa",
     "wof:parent_id":85671109,
     "wof:placetype":"county",

--- a/data/110/875/838/5/1108758385.geojson
+++ b/data/110/875/838/5/1108758385.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.058384,
-    "geom:area_square_m":697025076.494465,
+    "geom:area_square_m":697025076.494474,
     "geom:bbox":"38.9036854642,14.920269334,39.1784574443,15.264019199",
     "geom:latitude":15.091366,
     "geom:longitude":39.029659,
@@ -127,9 +127,10 @@
     "wof:concordances":{
         "hasc:id":"ER.DU.DE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ER",
     "wof:created":1481310374,
-    "wof:geomhash":"43b35934deb22c80862ac3d4c6da40ac",
+    "wof:geomhash":"253c599e3b47c1159246b2e7daabc459",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -139,7 +140,7 @@
         }
     ],
     "wof:id":1108758385,
-    "wof:lastmodified":1566587047,
+    "wof:lastmodified":1695886661,
     "wof:name":"Dekemhare",
     "wof:parent_id":85671109,
     "wof:placetype":"county",

--- a/data/110/875/838/7/1108758387.geojson
+++ b/data/110/875/838/7/1108758387.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.034617,
-    "geom:area_square_m":413979372.766129,
+    "geom:area_square_m":413979377.915304,
     "geom:bbox":"38.608402,14.575017,38.822607,14.859165",
     "geom:latitude":14.728693,
     "geom:longitude":38.713446,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"ER.DU.EH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ER",
     "wof:created":1481310375,
-    "wof:geomhash":"794f9dcd02c92455d334f6c709c1b176",
+    "wof:geomhash":"a753c1be478dd35d7d0a12307820407e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1108758387,
-    "wof:lastmodified":1627522106,
+    "wof:lastmodified":1695886581,
     "wof:name":"Emni Haili",
     "wof:parent_id":85671109,
     "wof:placetype":"county",

--- a/data/110/875/838/9/1108758389.geojson
+++ b/data/110/875/838/9/1108758389.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.066485,
-    "geom:area_square_m":794791018.727368,
+    "geom:area_square_m":794790921.11908,
     "geom:bbox":"38.901462,14.633866,39.282568,14.932987",
     "geom:latitude":14.810163,
     "geom:longitude":39.069972,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"ER.DU.MI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ER",
     "wof:created":1481310376,
-    "wof:geomhash":"6a40a8c251c001c5ffe4042eeebefb38",
+    "wof:geomhash":"27f14d735f59d45a98fda3cbc7999232",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1108758389,
-    "wof:lastmodified":1627522107,
+    "wof:lastmodified":1695886582,
     "wof:name":"Maiaini",
     "wof:parent_id":85671109,
     "wof:placetype":"county",

--- a/data/110/875/839/1/1108758391.geojson
+++ b/data/110/875/839/1/1108758391.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.085949,
-    "geom:area_square_m":1028615040.543979,
+    "geom:area_square_m":1028615070.876227,
     "geom:bbox":"38.265342,14.407522,38.693465,14.698062",
     "geom:latitude":14.565357,
     "geom:longitude":38.503795,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"ER.DU.MM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ER",
     "wof:created":1481310377,
-    "wof:geomhash":"e7e64fac64045656239eb7ab1bbb7f69",
+    "wof:geomhash":"4070fbdabaf4e50b0bb032cc40dec64f",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1108758391,
-    "wof:lastmodified":1627522107,
+    "wof:lastmodified":1695886582,
     "wof:name":"Maimine",
     "wof:parent_id":85671109,
     "wof:placetype":"county",

--- a/data/110/875/839/5/1108758395.geojson
+++ b/data/110/875/839/5/1108758395.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.052729,
-    "geom:area_square_m":630119208.497356,
+    "geom:area_square_m":630119067.860596,
     "geom:bbox":"38.667433,14.731685,38.973568,14.996931",
     "geom:latitude":14.887611,
     "geom:longitude":38.820575,
@@ -163,9 +163,10 @@
     "wof:concordances":{
         "hasc:id":"ER.DU.MF"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ER",
     "wof:created":1481310380,
-    "wof:geomhash":"82816a47240f561f89ac8282add46c6e",
+    "wof:geomhash":"c120a88353493557e48325dd01d9bdcf",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -175,7 +176,7 @@
         }
     ],
     "wof:id":1108758395,
-    "wof:lastmodified":1636502502,
+    "wof:lastmodified":1695886064,
     "wof:name":"Mendefera",
     "wof:parent_id":85671109,
     "wof:placetype":"county",

--- a/data/110/875/839/7/1108758397.geojson
+++ b/data/110/875/839/7/1108758397.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.051734,
-    "geom:area_square_m":617794084.884051,
+    "geom:area_square_m":617794253.161011,
     "geom:bbox":"39.078698,14.876097,39.322202,15.243285",
     "geom:latitude":15.039041,
     "geom:longitude":39.202918,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"ER.DU.SG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ER",
     "wof:created":1481310381,
-    "wof:geomhash":"9b28ccf58707350be8b5bbe7f6fa10b5",
+    "wof:geomhash":"35e32eacfb37fccabf520a0d85d4ffcd",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1108758397,
-    "wof:lastmodified":1627522108,
+    "wof:lastmodified":1695886583,
     "wof:name":"Segheneity",
     "wof:parent_id":85671109,
     "wof:placetype":"county",

--- a/data/110/875/839/9/1108758399.geojson
+++ b/data/110/875/839/9/1108758399.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.08176,
-    "geom:area_square_m":977944066.061616,
+    "geom:area_square_m":977944220.506255,
     "geom:bbox":"39.314882,14.483501,39.654795,14.92675",
     "geom:latitude":14.686169,
     "geom:longitude":39.49282,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"ER.DU.SF"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ER",
     "wof:created":1481310382,
-    "wof:geomhash":"9a7abfef218ab3a843d1c2d414e5ea1c",
+    "wof:geomhash":"2a593fdbe7d93fb622ef44eb15b25e96",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1108758399,
-    "wof:lastmodified":1627522108,
+    "wof:lastmodified":1695886584,
     "wof:name":"Sena'fe",
     "wof:parent_id":85671109,
     "wof:placetype":"county",

--- a/data/110/875/840/1/1108758401.geojson
+++ b/data/110/875/840/1/1108758401.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.057171,
-    "geom:area_square_m":683951919.508961,
+    "geom:area_square_m":683951724.126309,
     "geom:bbox":"39.04158,14.409358,39.371579,14.802746",
     "geom:latitude":14.650065,
     "geom:longitude":39.238638,
@@ -64,9 +64,10 @@
     "wof:concordances":{
         "hasc:id":"ER.DU.TS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ER",
     "wof:created":1481310384,
-    "wof:geomhash":"fa5ebb6cfd7e80372510a8fae27806ea",
+    "wof:geomhash":"24880f5de1d2a9df196d13a273f1b90f",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -76,7 +77,7 @@
         }
     ],
     "wof:id":1108758401,
-    "wof:lastmodified":1627522109,
+    "wof:lastmodified":1695886584,
     "wof:name":"Tsorona",
     "wof:parent_id":85671109,
     "wof:placetype":"county",

--- a/data/110/880/592/5/1108805925.geojson
+++ b/data/110/880/592/5/1108805925.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.087625,
-    "geom:area_square_m":1044830637.781505,
+    "geom:area_square_m":1044830943.530071,
     "geom:bbox":"38.695835,15.168501,39.046215,15.570337",
     "geom:latitude":15.35277,
     "geom:longitude":38.880665,
@@ -279,12 +279,14 @@
         "gn:id":448501,
         "gp:id":24549682,
         "hasc:id":"ER.MA",
+        "iso:code":"ER-MA",
         "iso:id":"ER-MA",
         "wd:id":"Q27710"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"ER",
     "wof:created":1485912888,
-    "wof:geomhash":"0592873de8630ed5d7dfdf512fa42f16",
+    "wof:geomhash":"6f38274e9842384df99e202d79edecc0",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -303,7 +305,7 @@
         "eng",
         "ara"
     ],
-    "wof:lastmodified":1690877007,
+    "wof:lastmodified":1695884935,
     "wof:name":"Central",
     "wof:parent_id":85632781,
     "wof:placetype":"region",

--- a/data/110/880/592/7/1108805927.geojson
+++ b/data/110/880/592/7/1108805927.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.78301,
-    "geom:area_square_m":21148562997.145096,
+    "geom:area_square_m":21148562372.973755,
     "geom:bbox":"36.859015,15.509174,38.889452,17.505165",
     "geom:latitude":16.409749,
     "geom:longitude":37.777688,
@@ -233,12 +233,14 @@
     "wof:concordances":{
         "fips:code":"ER01",
         "hasc:id":"ER.AN",
+        "iso:code":"ER-AN",
         "iso:id":"ER-AN",
         "wd:id":"Q569468"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"ER",
     "wof:created":1485912890,
-    "wof:geomhash":"e34f1ceafe58508295ae937d1b27389c",
+    "wof:geomhash":"57459f1cb3914e902f80e41d7e6aa1ee",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -257,7 +259,7 @@
         "eng",
         "ara"
     ],
-    "wof:lastmodified":1690877007,
+    "wof:lastmodified":1695884935,
     "wof:name":"Anseba",
     "wof:parent_id":85632781,
     "wof:placetype":"region",

--- a/data/856/327/81/85632781.geojson
+++ b/data/856/327/81/85632781.geojson
@@ -1195,6 +1195,7 @@
         "hasc:id":"ER",
         "icao:code":"E3",
         "ioc:id":"ERI",
+        "iso:code":"ER",
         "itu:id":"ERI",
         "loc:id":"n93074182",
         "m49:code":"232",
@@ -1208,6 +1209,7 @@
         "wd:id":"Q986",
         "wk:page":"Eritrea"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"ER",
     "wof:country_alpha3":"ERI",
     "wof:geom_alt":[
@@ -1233,7 +1235,7 @@
         "eng",
         "ara"
     ],
-    "wof:lastmodified":1694639554,
+    "wof:lastmodified":1695881212,
     "wof:name":"Eritrea",
     "wof:parent_id":102191573,
     "wof:placetype":"country",

--- a/data/856/711/01/85671101.geojson
+++ b/data/856/711/01/85671101.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.806885,
-    "geom:area_square_m":33494068330.460716,
+    "geom:area_square_m":33494068748.110798,
     "geom:bbox":"36.433348,14.180792,38.769814,16.321411",
     "geom:latitude":15.189806,
     "geom:longitude":37.418932,
@@ -301,17 +301,19 @@
         "gn:id":448500,
         "gp:id":24549681,
         "hasc:id":"ER.GB",
+        "iso:code":"ER-GB",
         "iso:id":"ER-GB",
         "qs_pg:id":483503,
         "unlc:id":"ER-GB",
         "wd:id":"Q873012",
         "wk:page":"Gash-Barka Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"ER",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"de5fef4e53fcb78e3b3df1803d948193",
+    "wof:geomhash":"138f7a97bfbb8547390e28cb1d4cad3d",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -330,7 +332,7 @@
         "eng",
         "ara"
     ],
-    "wof:lastmodified":1690877006,
+    "wof:lastmodified":1695884934,
     "wof:name":"Gash Barka",
     "wof:parent_id":85632781,
     "wof:placetype":"region",

--- a/data/856/711/05/85671105.geojson
+++ b/data/856/711/05/85671105.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.944227,
-    "geom:area_square_m":34961816417.068298,
+    "geom:area_square_m":34961815738.0877,
     "geom:bbox":"37.850879,14.299216,40.859585,18.020414",
     "geom:latitude":16.164337,
     "geom:longitude":39.067235,
@@ -279,16 +279,18 @@
         "gn:id":448502,
         "gp:id":24549686,
         "hasc:id":"ER.SK",
+        "iso:code":"ER-SK",
         "iso:id":"ER-SK",
         "qs_pg:id":1287877,
         "wd:id":"Q27910",
         "wk:page":"Northern Red Sea Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"ER",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"f19d7ddb15ee2417e905c812ff08c9eb",
+    "wof:geomhash":"902d9bfceba2369efa30c1a689acc3be",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -307,7 +309,7 @@
         "eng",
         "ara"
     ],
-    "wof:lastmodified":1690877005,
+    "wof:lastmodified":1695884934,
     "wof:name":"Debub",
     "wof:parent_id":85632781,
     "wof:placetype":"region",

--- a/data/856/711/09/85671109.geojson
+++ b/data/856/711/09/85671109.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.796307,
-    "geom:area_square_m":9518639354.49535,
+    "geom:area_square_m":9518639195.703054,
     "geom:bbox":"38.199216,14.407522,39.654795,15.264019",
     "geom:latitude":14.825648,
     "geom:longitude":38.933186,
@@ -298,16 +298,18 @@
         "gn:id":448498,
         "gp:id":24549683,
         "hasc:id":"ER.DU",
+        "iso:code":"ER-DU",
         "iso:id":"ER-DU",
         "qs_pg:id":212429,
         "wd:id":"Q27728",
         "wk:page":"Southern Region (Eritrea)"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"ER",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"52dac8bbe9c3720d559456a5a3566512",
+    "wof:geomhash":"dadc8c49943029f6affb0bfd84cb9857",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -326,7 +328,7 @@
         "eng",
         "ara"
     ],
-    "wof:lastmodified":1690877006,
+    "wof:lastmodified":1695884934,
     "wof:name":"Maekel",
     "wof:parent_id":85632781,
     "wof:placetype":"region",

--- a/data/856/711/11/85671111.geojson
+++ b/data/856/711/11/85671111.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.782102,
-    "geom:area_square_m":21414473380.683739,
+    "geom:area_square_m":21414472543.618343,
     "geom:bbox":"40.477716,12.387868,43.137048,15.022083",
     "geom:latitude":13.626164,
     "geom:longitude":41.719581,
@@ -303,16 +303,18 @@
         "gn:id":448499,
         "gp:id":24549685,
         "hasc:id":"ER.DK",
+        "iso:code":"ER-DK",
         "iso:id":"ER-DK",
         "qs_pg:id":888271,
         "wd:id":"Q27928",
         "wk:page":"Southern Red Sea Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"ER",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"de63f52f7a8ae5e228aad6d2a276cc9e",
+    "wof:geomhash":"11388e83154cb0e0c0912fec44ad3a08",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -331,7 +333,7 @@
         "eng",
         "ara"
     ],
-    "wof:lastmodified":1690877005,
+    "wof:lastmodified":1695884934,
     "wof:name":"Debubawi Keyih Bahri",
     "wof:parent_id":85632781,
     "wof:placetype":"region",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.